### PR TITLE
fix(contracts): critical _from on sendToChain func

### DIFF
--- a/contracts/Bridge.sol
+++ b/contracts/Bridge.sol
@@ -64,7 +64,6 @@ contract Bridge is NonblockingLzApp, AccessControl, Pausable, IBridge {
     }
 
     function sendToChain(
-        address _from,
         uint16 _dstChainId,
         bytes32 _resourceID,
         bytes calldata _data, // {resourceID,amount,toAddress}
@@ -76,7 +75,7 @@ contract Bridge is NonblockingLzApp, AccessControl, Pausable, IBridge {
 
         // Get handler and deposit into safe
         IDepositExecute depositHandler = IDepositExecute(handlerAddress);
-        depositHandler.deposit(_resourceID, _from, _data);
+        depositHandler.deposit(_resourceID, msg.sender, _data);
 
         _lzSend(_dstChainId, _data, payable(msg.sender), address(0x0), _adapterParams);
 

--- a/test/contracts/Bridge.js
+++ b/test/contracts/Bridge.js
@@ -113,9 +113,7 @@ describe('Bridge', function () {
       [1, 350000]
     );
     await this.srcBridge.sendToChain(
-      this.walletAddress,
       this.dstChainId,
-      this.resourceID,
       data,
       adapterParams,
       { value: 20_000_000_000 }
@@ -127,9 +125,7 @@ describe('Bridge', function () {
 
     // Send one more
     await this.srcBridge.sendToChain(
-      this.walletAddress,
       this.dstChainId,
-      this.resourceID,
       data,
       adapterParams,
       { value: 20_000_000_000 }
@@ -138,9 +134,7 @@ describe('Bridge', function () {
     // Expect receive from dst
     await this.dstToken.approve(this.dstHandler.address, sendAmount.mul(10));
     await this.dstBridge.sendToChain(
-      this.walletAddress,
       this.srcChainId,
-      this.resourceID,
       process.env.RESOURCE_ID + // Resource ID           (32 bytes)
         ethers.utils.hexZeroPad(sendAmount.toHexString(), 32).substring(2) + // Deposit Amount        (32 bytes)
         this.walletAddress.substring(2) +


### PR DESCRIPTION
- Issue:
`_from` can be pass by any value in `sendToChain` function of Bridge contract:
- Resolve:
we should not pass _from address and using msg.sender instead