### PR TITLE
fix(contracts): use resource ID from data

### DIFF
--- a/contracts/Bridge.sol
+++ b/contracts/Bridge.sol
@@ -66,17 +66,17 @@ contract Bridge is NonblockingLzApp, AccessControl, Pausable, IBridge {
     function sendToChain(
         address _from,
         uint16 _dstChainId,
-        bytes32 _resourceID,
         bytes calldata _data, // {resourceID,amount,toAddress}
         bytes calldata _adapterParams
     ) external payable virtual whenNotPaused {
         // First get resource handler ID and verify
-        address handlerAddress = _resourceIDToHandlerAddress[_resourceID];
-        require(handlerAddress != address(0), "this _resourceID not mapped to any handler");
+        bytes32 resourceID = abi.decode(_data, (bytes32));
+        address handlerAddress = _resourceIDToHandlerAddress[resourceID];
+        require(handlerAddress != address(0), "this resourceID not mapped to any handler");
 
         // Get handler and deposit into safe
         IDepositExecute depositHandler = IDepositExecute(handlerAddress);
-        depositHandler.deposit(_resourceID, _from, _data);
+        depositHandler.deposit(resourceID, _from, _data);
 
         _lzSend(_dstChainId, _data, payable(msg.sender), address(0x0), _adapterParams);
 

--- a/contracts/Bridge.sol
+++ b/contracts/Bridge.sol
@@ -67,6 +67,7 @@ contract Bridge is NonblockingLzApp, AccessControl, Pausable, IBridge {
         uint16 _dstChainId,
         bytes32 _resourceID,
         bytes calldata _data, // {amount,toAddress}
+        address payingInZro,
         bytes calldata _adapterParams
     ) external payable virtual whenNotPaused {
         // First get resource handler ID and verify
@@ -80,7 +81,7 @@ contract Bridge is NonblockingLzApp, AccessControl, Pausable, IBridge {
         // Encode payload for sending via LZ
         bytes memory payload = abi.encode(_resourceID, _data);
 
-        _lzSend(_dstChainId, payload, payable(msg.sender), address(0x0), _adapterParams);
+        _lzSend(_dstChainId, payload, payable(msg.sender), payingInZro, _adapterParams);
 
         uint64 nonce = lzEndpoint.getOutboundNonce(_dstChainId, address(this));
         emit SendToChain(msg.sender, _dstChainId, payload, nonce);

--- a/contracts/Bridge.sol
+++ b/contracts/Bridge.sol
@@ -50,17 +50,17 @@ contract Bridge is NonblockingLzApp, AccessControl, Pausable, IBridge {
     /**
         @notice Override for estimate send fees for current chain to dst chain
         @param _dstChainId ID of chain to send
-        @param _data bytes data to send {resourceID,amount,toAddress}
+        @param _payload bytes data to send
         @param _useZro use Zro?
         @param _adapterParams additional params
      */
     function estimateSendFee(
         uint16 _dstChainId,
-        bytes memory _data,
+        bytes memory _payload,
         bool _useZro,
         bytes memory _adapterParams
     ) public view virtual returns (uint256 nativeFee, uint256 zroFee) {
-        return lzEndpoint.estimateFees(_dstChainId, address(this), _data, _useZro, _adapterParams);
+        return lzEndpoint.estimateFees(_dstChainId, address(this), _payload, _useZro, _adapterParams);
     }
 
     function sendToChain(

--- a/contracts/handlers/ERC20Handler.sol
+++ b/contracts/handlers/ERC20Handler.sol
@@ -33,7 +33,7 @@ contract ERC20Handler is IDepositExecute, HandlerHelpers, ERC20Safe {
         address depositer,
         bytes calldata data
     ) external override onlyBridge returns (bytes memory) {
-        uint256 amount = abi.decode(data[32:64], (uint256));
+        uint256 amount = abi.decode(data, (uint256));
 
         address tokenAddress = _resourceIDToTokenContractAddress[resourceID];
         require(_contractWhitelist[tokenAddress], "provided tokenAddress is not whitelisted");
@@ -51,13 +51,12 @@ contract ERC20Handler is IDepositExecute, HandlerHelpers, ERC20Safe {
         @param data Consists of {resourceID}, {amount}, {toAddress},
         and {destinationRecipientAddress} all padded to 32 bytes.
         @notice Data passed into the function should be constructed as follows:
-        rID                                    bytes32     bytes  0 - 32
-        amount                                 uint256     bytes  32 - 64
-        toAddress                              bytes       bytes  64 - END
+        amount                                 uint256     bytes  0 - 32
+        toAddress                              bytes       bytes  32 - END
      */
     function execute(bytes32 resourceID, bytes calldata data) external override onlyBridge {
         address tokenAddress = _resourceIDToTokenContractAddress[resourceID];
-        (uint256 amount, bytes20 recipientAddress) = abi.decode(data[32:], (uint256, bytes20));
+        (uint256 amount, bytes20 recipientAddress) = abi.decode(data, (uint256, bytes20));
 
         require(_contractWhitelist[tokenAddress], "provided tokenAddress is not whitelisted");
 

--- a/contracts/handlers/ERC20Handler.sol
+++ b/contracts/handlers/ERC20Handler.sol
@@ -56,14 +56,14 @@ contract ERC20Handler is IDepositExecute, HandlerHelpers, ERC20Safe {
      */
     function execute(bytes32 resourceID, bytes calldata data) external override onlyBridge {
         address tokenAddress = _resourceIDToTokenContractAddress[resourceID];
-        (uint256 amount, bytes20 recipientAddress) = abi.decode(data, (uint256, bytes20));
+        (uint256 amount, address recipientAddress) = abi.decode(data, (uint256, address));
 
         require(_contractWhitelist[tokenAddress], "provided tokenAddress is not whitelisted");
 
         if (_burnList[tokenAddress]) {
-            mintERC20(tokenAddress, address(recipientAddress), amount);
+            mintERC20(tokenAddress, recipientAddress, amount);
         } else {
-            releaseERC20(tokenAddress, address(recipientAddress), amount);
+            releaseERC20(tokenAddress, recipientAddress, amount);
         }
     }
 }

--- a/tasks/transfer-erc20.js
+++ b/tasks/transfer-erc20.js
@@ -21,8 +21,7 @@ module.exports = async function (taskArgs, hre) {
   );
   const { ethers } = hre;
 
-  const data =
-    process.env.RESOURCE_ID + // Resource ID           (32 bytes)
+  const rawData =
     ethers.utils
       .hexZeroPad(
         ethers.utils.parseEther(String(taskArgs.amount)).toHexString(),
@@ -37,10 +36,10 @@ module.exports = async function (taskArgs, hre) {
     [1, 350000]
   );
 
-  // Estimate fee
+  // padding resourceID for estimate send fee
   let sendFeeResp = await srcBridge.estimateSendFee(
     taskArgs.targetChainId,
-    data,
+    taskArgs.resourceId + rawData,
     true,
     adapterParams
   );
@@ -48,10 +47,9 @@ module.exports = async function (taskArgs, hre) {
 
   // Call send to chain
   const tx = await srcBridge.sendToChain(
-    taskArgs.owner.address,
     taskArgs.targetChainId,
     taskArgs.resourceId,
-    data,
+    '0x' + rawData,
     adapterParams,
     {
       value: sendFee,

--- a/tasks/transfer-erc20.js
+++ b/tasks/transfer-erc20.js
@@ -28,8 +28,8 @@ module.exports = async function (taskArgs, hre) {
         32
       )
       .substring(2) + // Deposit Amount        (32 bytes)
-    taskArgs.recipient.substring(2) +
-    '000000000000000000000000'; // RecipientAddress      (32 bytes)
+      '000000000000000000000000' +
+      taskArgs.recipient.substring(2); // RecipientAddress     (32 bytes)
 
   const adapterParams = ethers.utils.solidityPack(
     ['uint16', 'uint256'],

--- a/tasks/transfer-erc20.js
+++ b/tasks/transfer-erc20.js
@@ -50,6 +50,7 @@ module.exports = async function (taskArgs, hre) {
     taskArgs.targetChainId,
     taskArgs.resourceId,
     '0x' + rawData,
+    "0x0000000000000000000000000000000000000000",
     adapterParams,
     {
       value: sendFee,

--- a/test/contracts/Bridge.js
+++ b/test/contracts/Bridge.js
@@ -116,6 +116,7 @@ describe('Bridge', function () {
       this.dstChainId,
       this.resourceID,
       data,
+      "0x0000000000000000000000000000000000000000",
       adapterParams,
       { value: 20_000_000_000 }
     );
@@ -129,6 +130,7 @@ describe('Bridge', function () {
       this.dstChainId,
       this.resourceID,
       data,
+      "0x0000000000000000000000000000000000000000",
       adapterParams,
       { value: 20_000_000_000 }
     );
@@ -142,6 +144,7 @@ describe('Bridge', function () {
         ethers.utils.hexZeroPad(sendAmount.toHexString(), 32).substring(2) + // Deposit Amount        (32 bytes)
         this.walletAddress.substring(2) +
         '000000000000000000000000', // RecipientAddress      (32 bytes),
+      "0x0000000000000000000000000000000000000000",
       adapterParams,
       { value: 20_000_000_000 }
     );

--- a/test/contracts/Bridge.js
+++ b/test/contracts/Bridge.js
@@ -105,8 +105,8 @@ describe('Bridge', function () {
     const data =
       '0x' +
       ethers.utils.hexZeroPad(sendAmount.toHexString(), 32).substring(2) + // Deposit Amount        (32 bytes)
-      this.walletAddress.substring(2) +
-      '000000000000000000000000'; // RecipientAddress + 0 pads      (32 bytes)
+      '000000000000000000000000' +
+      this.walletAddress.substring(2); // RecipientAddress + 0 pads      (32 bytes)
 
     const adapterParams = ethers.utils.solidityPack(
       ['uint16', 'uint256'],
@@ -116,7 +116,7 @@ describe('Bridge', function () {
       this.dstChainId,
       this.resourceID,
       data,
-      "0x0000000000000000000000000000000000000000",
+      '0x0000000000000000000000000000000000000000',
       adapterParams,
       { value: 20_000_000_000 }
     );
@@ -130,7 +130,7 @@ describe('Bridge', function () {
       this.dstChainId,
       this.resourceID,
       data,
-      "0x0000000000000000000000000000000000000000",
+      '0x0000000000000000000000000000000000000000',
       adapterParams,
       { value: 20_000_000_000 }
     );
@@ -142,9 +142,9 @@ describe('Bridge', function () {
       this.resourceID,
       '0x' +
         ethers.utils.hexZeroPad(sendAmount.toHexString(), 32).substring(2) + // Deposit Amount        (32 bytes)
-        this.walletAddress.substring(2) +
-        '000000000000000000000000', // RecipientAddress      (32 bytes),
-      "0x0000000000000000000000000000000000000000",
+        '000000000000000000000000' +
+        this.walletAddress.substring(2), // RecipientAddress      (32 bytes),
+      '0x0000000000000000000000000000000000000000',
       adapterParams,
       { value: 20_000_000_000 }
     );
@@ -153,6 +153,6 @@ describe('Bridge', function () {
     expect(dstBalance.toString()).to.be.eq(sendAmount.toString());
 
     const srcBalance = await this.srcToken.balanceOf(this.walletAddress);
-    expect(srcBalance.toString().startsWith("99")).to.be.true;
+    expect(srcBalance.toString().startsWith('99')).to.be.true;
   });
 });

--- a/test/contracts/Bridge.js
+++ b/test/contracts/Bridge.js
@@ -103,7 +103,7 @@ describe('Bridge', function () {
     await this.srcToken.approve(this.srcHandler.address, sendAmount.mul(10));
     // Then send token
     const data =
-      process.env.RESOURCE_ID + // Resource ID           (32 bytes)
+      '0x' +
       ethers.utils.hexZeroPad(sendAmount.toHexString(), 32).substring(2) + // Deposit Amount        (32 bytes)
       this.walletAddress.substring(2) +
       '000000000000000000000000'; // RecipientAddress + 0 pads      (32 bytes)
@@ -113,7 +113,6 @@ describe('Bridge', function () {
       [1, 350000]
     );
     await this.srcBridge.sendToChain(
-      this.walletAddress,
       this.dstChainId,
       this.resourceID,
       data,
@@ -127,7 +126,6 @@ describe('Bridge', function () {
 
     // Send one more
     await this.srcBridge.sendToChain(
-      this.walletAddress,
       this.dstChainId,
       this.resourceID,
       data,
@@ -138,10 +136,9 @@ describe('Bridge', function () {
     // Expect receive from dst
     await this.dstToken.approve(this.dstHandler.address, sendAmount.mul(10));
     await this.dstBridge.sendToChain(
-      this.walletAddress,
       this.srcChainId,
       this.resourceID,
-      process.env.RESOURCE_ID + // Resource ID           (32 bytes)
+      '0x' +
         ethers.utils.hexZeroPad(sendAmount.toHexString(), 32).substring(2) + // Deposit Amount        (32 bytes)
         this.walletAddress.substring(2) +
         '000000000000000000000000', // RecipientAddress      (32 bytes),


### PR DESCRIPTION
- Issue:
`_resourceID` parameter and `resourceID` in `_data` parameter is not consistent
- Resolve:
We should not encode `resourceID` into `data`, but using param `_resourceID` in param instead